### PR TITLE
Add timezone switch clock to home page

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -7,6 +7,7 @@ import 'services/supabase_service.dart';
 import 'services/discord_service.dart';
 import 'login_page.dart';
 import 'widgets/home_content.dart';
+import 'widgets/timezone_switch.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -25,6 +26,7 @@ class _HomePageState extends State<HomePage> {
   UserSettings? currentUserSettings;
   bool isLoading = true;
   bool isLoggedIn = false;
+  String timezone = 'Europe/Prague';
 
   @override
   void initState() {
@@ -163,29 +165,37 @@ class _HomePageState extends State<HomePage> {
       );
     }
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Status Checker'),
-        actions: [
-          if (isLoggedIn)
-            IconButton(
-              icon: const Icon(Icons.logout),
-              tooltip: 'Logout',
-              onPressed: _signOut,
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('Status Checker'),
+          actions: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: TimezoneSwitchWidget(
+                selectedTimezone: timezone,
+                onChanged: (tz) => setState(() => timezone = tz),
+              ),
             ),
-        ],
-      ),
-      body: HomeContent(
-        isLoggedIn: isLoggedIn,
-        publicPages: publicPages,
-        userPages: userPages,
-        onAddUrl: _addUserUrl,
-        onDeleteUrl: _deleteUserUrl,
-        onEditUrl: _editUserUrl,
-        currentUserSettings: currentUserSettings,
-        onUpdateUserSettings: _updateUserSettings,
-        onLoadDiscordWebhookUrl: _loadDiscordWebhookUrl,
-      ),
-    );
+            if (isLoggedIn)
+              IconButton(
+                icon: const Icon(Icons.logout),
+                tooltip: 'Logout',
+                onPressed: _signOut,
+              ),
+          ],
+        ),
+        body: HomeContent(
+          isLoggedIn: isLoggedIn,
+          publicPages: publicPages,
+          userPages: userPages,
+          onAddUrl: _addUserUrl,
+          onDeleteUrl: _deleteUserUrl,
+          onEditUrl: _editUserUrl,
+          currentUserSettings: currentUserSettings,
+          onUpdateUserSettings: _updateUserSettings,
+          onLoadDiscordWebhookUrl: _loadDiscordWebhookUrl,
+          timezone: timezone,
+        ),
+      );
   }
 }

--- a/lib/widgets/home_content.dart
+++ b/lib/widgets/home_content.dart
@@ -15,6 +15,7 @@ class HomeContent extends StatefulWidget {
   final UserSettings? currentUserSettings;
   final Future<void> Function({String? discordWebhookUrl, bool? isAdmin}) onUpdateUserSettings;
   final Future<String?> Function() onLoadDiscordWebhookUrl;
+  final String timezone;
 
   const HomeContent({
     super.key,
@@ -27,6 +28,7 @@ class HomeContent extends StatefulWidget {
     this.currentUserSettings,
     required this.onUpdateUserSettings,
     required this.onLoadDiscordWebhookUrl,
+    required this.timezone,
   });
 
   @override
@@ -320,7 +322,7 @@ class _HomeContentState extends State<HomeContent> {
             (entry) => Card(
               margin: const EdgeInsets.symmetric(vertical: 8),
               child: ListTile(
-                title: PageStatusRowWidget(page: entry, timezone: "Europe/Prague"),
+                title: PageStatusRowWidget(page: entry, timezone: widget.timezone),
                 trailing: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
@@ -351,7 +353,7 @@ class _HomeContentState extends State<HomeContent> {
           (entry) => Card(
             margin: const EdgeInsets.symmetric(vertical: 8),
             child: ListTile(
-              title: PageStatusRowWidget(page: entry, timezone: "Europe/Prague"),
+              title: PageStatusRowWidget(page: entry, timezone: widget.timezone),
             ),
           ),
         ),

--- a/lib/widgets/timezone_switch.dart
+++ b/lib/widgets/timezone_switch.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'dart:async';
 
-class TimezoneSwitchWidget extends StatelessWidget {
+class TimezoneSwitchWidget extends StatefulWidget {
   final String selectedTimezone;
   final void Function(String timezone) onChanged;
 
@@ -11,19 +13,66 @@ class TimezoneSwitchWidget extends StatelessWidget {
   });
 
   @override
+  State<TimezoneSwitchWidget> createState() => _TimezoneSwitchWidgetState();
+}
+
+class _TimezoneSwitchWidgetState extends State<TimezoneSwitchWidget> {
+  late Timer _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(minutes: 1), (_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
+
+  DateTime _pragueTime(DateTime utc) {
+    int year = utc.year;
+    DateTime lastSunday(int month) {
+      var date = DateTime.utc(year, month + 1, 1).subtract(const Duration(days: 1));
+      while (date.weekday != DateTime.sunday) {
+        date = date.subtract(const Duration(days: 1));
+      }
+      return date;
+    }
+
+    final start = DateTime.utc(year, 3, lastSunday(3).day, 1); // DST start 01:00 UTC
+    final end = DateTime.utc(year, 10, lastSunday(10).day, 1); // DST end 01:00 UTC
+    final isDst = utc.isAfter(start) && utc.isBefore(end);
+    final offset = isDst ? 2 : 1;
+    return utc.add(Duration(hours: offset));
+  }
+
+  String _formattedTime() {
+    DateTime utc = DateTime.now().toUtc();
+    DateTime displayTime =
+        widget.selectedTimezone == 'UTC' ? utc : _pragueTime(utc);
+    return DateFormat('HH:mm').format(displayTime);
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Row(
       children: [
         const Icon(Icons.access_time, size: 18),
         const SizedBox(width: 4),
+        Text(_formattedTime(), style: const TextStyle(fontSize: 13)),
+        const SizedBox(width: 8),
         ToggleButtons(
           isSelected: [
-            selectedTimezone == 'Europe/Prague',
-            selectedTimezone == 'UTC',
+            widget.selectedTimezone == 'Europe/Prague',
+            widget.selectedTimezone == 'UTC',
           ],
           onPressed: (idx) {
-            if (idx == 0) onChanged('Europe/Prague');
-            if (idx == 1) onChanged('UTC');
+            if (idx == 0) widget.onChanged('Europe/Prague');
+            if (idx == 1) widget.onChanged('UTC');
           },
           borderRadius: BorderRadius.circular(6),
           constraints: const BoxConstraints(minWidth: 44, minHeight: 32),


### PR DESCRIPTION
## Summary
- enhance `TimezoneSwitchWidget` to show live time (HH:mm) for Prague or UTC
- show timezone switch on homepage
- pass timezone to `HomeContent`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b302b89c832e95726c26b0d7cf96