### PR TITLE
Add confirmation snackbars for dialog actions

### DIFF
--- a/lib/widgets/home_actions.dart
+++ b/lib/widgets/home_actions.dart
@@ -100,13 +100,16 @@ class HomeActions extends StatelessWidget {
                       borderRadius: BorderRadius.circular(12),
                     ),
                   ),
-                  onPressed: () {
+                  onPressed: () async {
                     if (urlController.text.trim().isNotEmpty) {
-                      onAddUrl(
+                      await onAddUrl(
                         urlController.text.trim(),
                         nameController.text.trim().isEmpty ? null : nameController.text.trim(),
                       );
-                      Navigator.of(context).pop();
+                      ScaffoldMessenger.of(dialogContext).showSnackBar(
+                        const SnackBar(content: Text('Page added.')),
+                      );
+                      Navigator.of(dialogContext).pop();
                     }
                   },
                   child: const Text('Add'),
@@ -188,12 +191,13 @@ class HomeActions extends StatelessWidget {
                   onPressed: () async {
                     final url = webhookController.text.trim();
                     if (url.isNotEmpty && url != currentWebhook) {
-                      Navigator.of(context).pop();
-                      // Tady případně otevři dialog pro ověření webhooku, nebo rovnou voláš onUpdateUserSettings:
                       await onUpdateUserSettings(discordWebhookUrl: url);
-                      // případně zobraz snackbar atd.
+                      ScaffoldMessenger.of(dialogContext).showSnackBar(
+                        const SnackBar(content: Text('Webhook saved')),
+                      );
+                      Navigator.of(dialogContext).pop();
                     } else {
-                      Navigator.of(context).pop();
+                      Navigator.of(dialogContext).pop();
                     }
                   },
                   child: const Text('Verify & Save'),

--- a/lib/widgets/home_user_pages.dart
+++ b/lib/widgets/home_user_pages.dart
@@ -24,7 +24,7 @@ Future<void> _showEditDialog(BuildContext context, UrlEntry entry) async {
   await showDialog<void>(
     context: context,
     barrierDismissible: false,
-    builder: (context) => AlertDialog(
+    builder: (dialogContext) => AlertDialog(
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(18),
         side: BorderSide(
@@ -102,15 +102,17 @@ Future<void> _showEditDialog(BuildContext context, UrlEntry entry) async {
                     borderRadius: BorderRadius.circular(12),
                   ),
                 ),
-                onPressed: () {
+                onPressed: () async {
                   if (editUrlController.text.trim().isEmpty) return;
-                  Navigator.of(context).pop();
-                  // Callback na edit:
-                  onEditUrl(
+                  await onEditUrl(
                     entry.id,
                     editUrlController.text.trim(),
                     editUrlNameController.text.trim().isEmpty ? null : editUrlNameController.text.trim(),
                   );
+                  ScaffoldMessenger.of(dialogContext).showSnackBar(
+                    const SnackBar(content: Text('Page updated.')),
+                  );
+                  Navigator.of(dialogContext).pop();
                 },
                 child: const Text('Save'),
               ),
@@ -123,9 +125,9 @@ Future<void> _showEditDialog(BuildContext context, UrlEntry entry) async {
 }
 
 Future<void> _showDeleteConfirmDialog(BuildContext context, String pageId) async {
-  final confirmed = await showDialog<bool>(
+  await showDialog<void>(
     context: context,
-    builder: (context) => AlertDialog(
+    builder: (dialogContext) => AlertDialog(
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(18),
         side: BorderSide(
@@ -185,7 +187,13 @@ Future<void> _showDeleteConfirmDialog(BuildContext context, String pageId) async
                     borderRadius: BorderRadius.circular(12),
                   ),
                 ),
-                onPressed: () => Navigator.of(context).pop(true),
+                onPressed: () async {
+                  await onDeleteUrl(pageId);
+                  ScaffoldMessenger.of(dialogContext).showSnackBar(
+                    const SnackBar(content: Text('Page deleted.')),
+                  );
+                  Navigator.of(dialogContext).pop();
+                },
                 child: const Text('Delete'),
               ),
             ),
@@ -194,10 +202,6 @@ Future<void> _showDeleteConfirmDialog(BuildContext context, String pageId) async
       ],
     ),
   );
-
-  if (confirmed == true) {
-    onDeleteUrl(pageId);
-  }
 }
 
   @override


### PR DESCRIPTION
## Summary
- show SnackBar when a page is added
- show SnackBar when a Discord webhook is saved

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430fddda80832eaf1313514f7a960c