### PR TITLE
Fix login button visibility on narrow screens

### DIFF
--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -149,30 +149,36 @@ void _showLoginDialog() {
         child: SafeArea(
           child: Padding(
             padding: const EdgeInsets.only(top: 6, right: 10),
-            child: Row(
-              children: [
-                const Spacer(),
-                TimezoneSwitchWidget(
-                  selectedTimezone: timezone,
-                  onChanged: (tz) => setState(() => timezone = tz),
-                ),
-                const SizedBox(width: 10),
-                IconButton(
-                  icon: Icon(
-                    widget.themeMode == ThemeMode.dark
-                        ? Icons.light_mode
-                        : Icons.dark_mode,
-                    size: 25,
-                  ),
-                  onPressed: widget.onToggleTheme,
-                  tooltip: 'Switch light/dark theme',
-                ),
-                IconButton(
-                  icon: const Icon(Icons.login),
-                  onPressed: _showLoginDialog,
-                  tooltip: 'Login',
-                ),
-              ],
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final showLoginButton = constraints.maxWidth > 450;
+                return Row(
+                  children: [
+                    const Spacer(),
+                    TimezoneSwitchWidget(
+                      selectedTimezone: timezone,
+                      onChanged: (tz) => setState(() => timezone = tz),
+                    ),
+                    const SizedBox(width: 10),
+                    IconButton(
+                      icon: Icon(
+                        widget.themeMode == ThemeMode.dark
+                            ? Icons.light_mode
+                            : Icons.dark_mode,
+                        size: 25,
+                      ),
+                      onPressed: widget.onToggleTheme,
+                      tooltip: 'Switch light/dark theme',
+                    ),
+                    if (showLoginButton)
+                      IconButton(
+                        icon: const Icon(Icons.login),
+                        onPressed: _showLoginDialog,
+                        tooltip: 'Login',
+                      ),
+                  ],
+                );
+              },
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- tweak AppBar layout in `login_page.dart`
- hide login icon button when screen width is narrow

## Testing
- `dart format -o none --set-exit-if-changed .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684315aeb220832ea101399024d3bbcc