### PR TITLE
Fix dialogs closing before updates

### DIFF
--- a/lib/widgets/home_actions.dart
+++ b/lib/widgets/home_actions.dart
@@ -103,14 +103,16 @@ class HomeActions extends StatelessWidget {
                   ),
                   onPressed: () async {
                     if (urlController.text.trim().isNotEmpty) {
+                      Navigator.of(dialogContext).pop();
                       await onAddUrl(
                         urlController.text.trim(),
                         nameController.text.trim().isEmpty ? null : nameController.text.trim(),
                       );
-                      ScaffoldMessenger.of(dialogContext).showSnackBar(
-                        const SnackBar(content: Text('Page added.')),
-                      );
-                      Navigator.of(dialogContext).pop();
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Page added.')),
+                        );
+                      }
                     }
                   },
                   child: const Text('Add'),
@@ -192,18 +194,21 @@ class HomeActions extends StatelessWidget {
                   ),
                   onPressed: () async {
                     final url = webhookController.text.trim();
+                    Navigator.of(dialogContext).pop();
                     if (url.isNotEmpty && url != currentWebhook) {
                       final sent = await discordService.sendVerificationCode(url);
                       if (!sent) {
-                        ScaffoldMessenger.of(dialogContext).showSnackBar(
-                          const SnackBar(content: Text('Failed to send verification code')),
-                        );
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('Failed to send verification code')),
+                          );
+                        }
                         return;
                       }
 
                       final codeController = TextEditingController();
                       final verified = await showDialog<bool>(
-                        context: dialogContext,
+                        context: context,
                         builder: (verifyContext) => AlertDialog(
                           title: const Text('Enter Verification Code'),
                           content: TextField(
@@ -234,13 +239,12 @@ class HomeActions extends StatelessWidget {
 
                       if (verified == true) {
                         await onUpdateUserSettings(discordWebhookUrl: url);
-                        ScaffoldMessenger.of(dialogContext).showSnackBar(
-                          const SnackBar(content: Text('Webhook saved')),
-                        );
-                        Navigator.of(dialogContext).pop();
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('Webhook saved')),
+                          );
+                        }
                       }
-                    } else {
-                      Navigator.of(dialogContext).pop();
                     }
                   },
                   child: const Text('Verify & Save'),

--- a/lib/widgets/home_user_pages.dart
+++ b/lib/widgets/home_user_pages.dart
@@ -104,15 +104,17 @@ Future<void> _showEditDialog(BuildContext context, UrlEntry entry) async {
                 ),
                 onPressed: () async {
                   if (editUrlController.text.trim().isEmpty) return;
+                  Navigator.of(dialogContext).pop();
                   await onEditUrl(
                     entry.id,
                     editUrlController.text.trim(),
                     editUrlNameController.text.trim().isEmpty ? null : editUrlNameController.text.trim(),
                   );
-                  ScaffoldMessenger.of(dialogContext).showSnackBar(
-                    const SnackBar(content: Text('Page updated.')),
-                  );
-                  Navigator.of(dialogContext).pop();
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Page updated.')),
+                    );
+                  }
                 },
                 child: const Text('Save'),
               ),
@@ -188,11 +190,13 @@ Future<void> _showDeleteConfirmDialog(BuildContext context, String pageId) async
                   ),
                 ),
                 onPressed: () async {
-                  await onDeleteUrl(pageId);
-                  ScaffoldMessenger.of(dialogContext).showSnackBar(
-                    const SnackBar(content: Text('Page deleted.')),
-                  );
                   Navigator.of(dialogContext).pop();
+                  await onDeleteUrl(pageId);
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Page deleted.')),
+                    );
+                  }
                 },
                 child: const Text('Delete'),
               ),


### PR DESCRIPTION
## Summary
- close add page dialog before saving and show snackbar on parent context
- close webhook dialog before verifying and show snackbar on parent context
- close edit/delete dialogs before running updates

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684317c8655c832e93ce0427e4ff4ec0