### PR TITLE
Allow selecting page info

### DIFF
--- a/lib/login_page.dart
+++ b/lib/login_page.dart
@@ -199,7 +199,7 @@ void _showLoginDialog() {
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        Text(
+                        SelectableText(
                           'Narrativva Status',
                           style: GoogleFonts.epilogue(
                             fontWeight: FontWeight.w800,
@@ -213,7 +213,7 @@ void _showLoginDialog() {
                       ],
                     ),
                     const SizedBox(height: 18),
-                    Text(
+                    SelectableText(
                       'Live status and uptime monitoring for all Narrativva apps and websites.',
                       style: GoogleFonts.inter(
                         fontSize: 18,

--- a/lib/widgets/home_actions.dart
+++ b/lib/widgets/home_actions.dart
@@ -291,7 +291,7 @@ class HomeActions extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            Text(
+            SelectableText(
               "Narrativva Status",
               style: GoogleFonts.epilogue(
                 fontSize: 40,
@@ -305,7 +305,7 @@ class HomeActions extends StatelessWidget {
           ],
         ),
         const SizedBox(height: 14),
-        Text(
+        SelectableText(
           "Live status and uptime monitoring for all Narrativva apps and websites.",
           style: GoogleFonts.inter(
             fontSize: 17,

--- a/lib/widgets/page_status_row.dart
+++ b/lib/widgets/page_status_row.dart
@@ -51,7 +51,7 @@ class PageStatusRowWidget extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Text(
+              SelectableText(
                 page.urlName?.isNotEmpty == true ? page.urlName! : page.url,
                 style: GoogleFonts.epilogue(
                   fontWeight: FontWeight.w700,
@@ -61,7 +61,7 @@ class PageStatusRowWidget extends StatelessWidget {
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 2),
-              Text(
+              SelectableText(
                 page.url,
                 style: GoogleFonts.inter(
                   fontSize: 12,


### PR DESCRIPTION
## Summary
- make login page text selectable
- allow selecting heading and description on home
- let users copy page names and URLs

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432d8b7318832ea66c6481b2bc730d